### PR TITLE
feat: configurable delta lookback (days) for incremental sync (SUPPORT-17281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Param 1
 Param 2
 -------
 
+Delta lookback (days)
+---------------------
+
+`source.delta_lookback_days` (integer, default `0`) applies only to `incremental_sync`. Before a run,
+the delta pointer stored in the state file is shifted back by the given number of days, so each run
+re-fetches an overlapping window of data. This is useful for tables where changes cannot be tracked
+reliably and a longer overlap (e.g. 10 days) is needed.
+
+The pointer must be a timestamp in `YYYYMMDD` or `YYYYMMDDHHMMSS` format; other pointer formats
+(e.g. sequential ids) cannot be shifted and are used as is (a warning is logged).
+
 Output
 ======
 

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -78,6 +78,19 @@
           "uniqueItems": true,
           "description": "DataSource pagination method",
           "propertyOrder": 5
+        },
+        "delta_lookback_days": {
+          "type": "integer",
+          "title": "Delta lookback (days)",
+          "default": 0,
+          "minimum": 0,
+          "description": "Only for incremental sync. Shifts the stored delta pointer back by the given number of days, so each run re-fetches an overlapping window (e.g. 10 = fetch everything changed since 10 days before the last pointer). Works only for timestamp based delta pointers (YYYYMMDD or YYYYMMDDHHMMSS).",
+          "propertyOrder": 6,
+          "options": {
+            "dependencies": {
+              "sync_type": "incremental_sync"
+            }
+          }
         }
       }
     },

--- a/src/component.py
+++ b/src/component.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+from datetime import datetime, timedelta
 from typing import Union
 
 from keboola.component.base import ComponentBase, sync_action
@@ -41,6 +42,7 @@ class Component(ComponentBase):
         batch_size = self._configuration.source.batch_size
         paging_method = self._configuration.source.paging_method
         sync_type = self._configuration.source.sync_type
+        delta_lookback_days = self._configuration.source.delta_lookback_days
 
         output_table_name = self._configuration.destination.output_table_name
         load_type = self._configuration.destination.load_type
@@ -51,7 +53,7 @@ class Component(ComponentBase):
 
         statefile_columns = self.state.get(resource_alias, {}).get("columns", [])
 
-        previous_delta_max = self._init_delta(sync_type, resource_alias)
+        previous_delta_max = self._init_delta(sync_type, resource_alias, delta_lookback_days)
 
         client = SAPClient(
             server_url=server_url,
@@ -113,7 +115,7 @@ class Component(ComponentBase):
 
         self.write_state_file(self.state)
 
-    def _init_delta(self, sync_mode: str, resource_alias: str) -> Union[bool, int, str]:
+    def _init_delta(self, sync_mode: str, resource_alias: str, lookback_days: int = 0) -> Union[bool, int, str]:
         """This method initializes delta sync by setting delta pointer to the last value from state file."""
         previous_delta_max = None
         if sync_mode == "incremental_sync":
@@ -124,8 +126,42 @@ class Component(ComponentBase):
                     "Delta sync is enabled, but no previous delta pointer was found in state file. "
                     "Full sync will be performed."
                 )
+            elif lookback_days:
+                previous_delta_max = self._shift_delta_pointer(previous_delta_max, lookback_days)
 
         return previous_delta_max
+
+    @staticmethod
+    def _shift_delta_pointer(delta_pointer: Union[int, str], lookback_days: int) -> Union[int, str]:
+        """Shifts a timestamp based delta pointer back by the given number of days.
+
+        Supported pointer formats are YYYYMMDD and YYYYMMDDHHMMSS. Pointers in any other format
+        (e.g. sequential ids) cannot be shifted and are returned unchanged.
+        """
+        if lookback_days < 0:
+            raise UserException("Delta lookback (days) must not be negative.")
+
+        pointer = str(delta_pointer)
+        date_format = {8: "%Y%m%d", 14: "%Y%m%d%H%M%S"}.get(len(pointer))
+
+        if date_format:
+            try:
+                shifted = datetime.strptime(pointer, date_format) - timedelta(days=lookback_days)
+            except ValueError:
+                shifted = None
+
+            if shifted:
+                new_pointer = shifted.strftime(date_format)
+                logging.info(
+                    f"Delta pointer {delta_pointer} was shifted back by {lookback_days} day(s) to {new_pointer}."
+                )
+                return int(new_pointer) if isinstance(delta_pointer, int) else new_pointer
+
+        logging.warning(
+            f"Delta lookback is set to {lookback_days} day(s), but the delta pointer {delta_pointer} is not "
+            f"a supported timestamp (YYYYMMDD or YYYYMMDDHHMMSS). The pointer will be used as is."
+        )
+        return delta_pointer
 
     @staticmethod
     def add_column_metadata(client: SAPClient, out_table: TableDefinition):

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -66,6 +66,7 @@ class Source(ConfigurationBase):
     paging_method: str
     limit: int = ConfigurationBase.DEFAULT_LIMIT
     batch_size: int = ConfigurationBase.DEFAULT_BATCH_SIZE
+    delta_lookback_days: int = 0
 
 
 @dataclass

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -8,6 +8,8 @@ import mock
 import os
 from freezegun import freeze_time
 
+from keboola.component.exceptions import UserException
+
 from component import Component
 
 
@@ -21,6 +23,40 @@ class TestComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             comp = Component()
             comp.run()
+
+
+class TestDeltaLookback(unittest.TestCase):
+
+    @staticmethod
+    def _component(state):
+        comp = Component.__new__(Component)
+        comp.state = state
+        return comp
+
+    def test_shift_full_timestamp(self):
+        self.assertEqual(Component._shift_delta_pointer(20260806021626, 10), 20260727021626)
+
+    def test_shift_date_only_keeps_type(self):
+        self.assertEqual(Component._shift_delta_pointer("20260301", 1), "20260228")
+
+    def test_unsupported_pointer_returned_as_is(self):
+        self.assertEqual(Component._shift_delta_pointer(12345, 10), 12345)
+
+    def test_negative_lookback_raises(self):
+        with self.assertRaises(UserException):
+            Component._shift_delta_pointer(20260806021626, -1)
+
+    def test_init_delta_applies_lookback(self):
+        comp = self._component({"RES": {"delta_max": 20260806021626}})
+        self.assertEqual(comp._init_delta("incremental_sync", "RES", 10), 20260727021626)
+
+    def test_init_delta_without_lookback(self):
+        comp = self._component({"RES": {"delta_max": 20260806021626}})
+        self.assertEqual(comp._init_delta("incremental_sync", "RES"), 20260806021626)
+
+    def test_init_delta_full_sync_ignores_lookback(self):
+        comp = self._component({"RES": {"delta_max": 20260806021626}})
+        self.assertIsNone(comp._init_delta("full_sync", "RES", 10))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

SUPPORT-17281: customer needs incremental sync to re-fetch an overlapping window for tables where changes can't be tracked reliably (e.g. "today - 10 days" instead of whatever `delta_max` the last run stored).

Adds `source.delta_lookback_days` (int, default `0`, incremental sync only). The stored pointer is shifted back before being sent to SAP as `delta_pointer`:

```python
previous_delta_max = state[alias]["delta_max"]          # e.g. 20260806021626
if lookback_days:
    previous_delta_max = _shift_delta_pointer(previous_delta_max, lookback_days)  # -> 20260727021626
```

`_shift_delta_pointer` parses `YYYYMMDD` / `YYYYMMDDHHMMSS`, subtracts the days and preserves the original type (int stays int). Pointers of other shapes (sequential ids) can't be shifted — they're returned unchanged with a warning, so behaviour is unaffected for those sources. Negative values raise `UserException`. The state written after the run is still the max pointer returned by SAP, so the window doesn't drift.

Also adds the field to `configRowSchema.json` (shown only for `incremental_sync`), README docs, and unit tests.

## Release Notes
**Justification, description**

Customers with SAP tables that cannot be tracked reliably by delta need to re-fetch a configurable overlap window on each incremental run.

**Plans for Customer Communication**

Reply on SUPPORT-17281 once released.

**Impact Analysis**

Opt-in; default `0` keeps current behaviour.

**Deployment Plan**

Standard component release (tag + Developer Portal deploy).

**Rollback Plan**

Revert to previous component tag.

**Post-Release Support Plan**

N/A


Link to Devin session: https://app.devin.ai/sessions/e5b2059c29834740b2a34e6f472b5fe2
Requested by: @OlenaMarchuk