### PR TITLE
kds-team.ex-sap: Date Start (configurable window start) for incremental sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Two requirements, both enforced with a clear error rather than silently ignored:
 - With `incremental_load`, SAP must report key columns for the table, so re-fetched
   rows are updated rather than appended as duplicates.
 
+Keep the window narrow. A delta fetch is a single un-paginated request, so the whole
+window has to come back in one response inside the configured `timeout`. The maximum
+accepted is 365 days, and anything above 31 logs a warning.
+
+The option only applies to `incremental_sync`. On a `full_sync` row, or on the first
+run of an incremental row where no pointer has been stored yet, it is inert - the run
+behaves exactly as it would with the option unset.
+
 Combining it with `full_load` only logs a warning - every run still overwrites the
 destination table with just the fetched window.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,36 @@ Param 1
 Param 2
 -------
 
+Delta lookback (days)
+---------------------
+
+`source.delta_lookback_days` (integer, default `0`, incremental sync only)
+
+By default an incremental run resumes exactly where the previous one stopped: it
+asks SAP for everything changed since the delta pointer stored in the
+configuration state. For source tables whose changes cannot be tracked reliably
+that leaves late changes behind.
+
+Set this to re-fetch an overlapping window on every run. With `10`, each run asks
+SAP for everything changed since *today minus 10 days*. The pointer sent is never
+newer than the stored one, so a schedule that is behind still resumes from where
+it left off rather than skipping the gap - the window is always a superset of what
+the run would have fetched otherwise.
+
+The pointer written back to state after the run is unaffected by the lookback: it
+never moves backwards, so the window stays anchored to the current date instead of
+creeping further back run after run.
+
+Two requirements, both enforced with a clear error rather than silently ignored:
+
+- The source's delta pointer must be a `YYYYMMDD` or `YYYYMMDDHHMMSS` timestamp.
+  Sequential id pointers cannot express a date window.
+- With `incremental_load`, SAP must report key columns for the table, so re-fetched
+  rows are updated rather than appended as duplicates.
+
+Combining it with `full_load` only logs a warning - every run still overwrites the
+destination table with just the fetched window.
+
 Output
 ======
 

--- a/README.md
+++ b/README.md
@@ -42,25 +42,30 @@ Param 1
 Param 2
 -------
 
-Delta lookback (days)
----------------------
+Date Start
+----------
 
-`source.delta_lookback_days` (integer, default `0`, incremental sync only)
+`source.date_from` (string, optional, incremental sync only)
 
 By default an incremental run resumes exactly where the previous one stopped: it
 asks SAP for everything changed since the delta pointer stored in the
 configuration state. For source tables whose changes cannot be tracked reliably
 that leaves late changes behind.
 
-Set this to re-fetch an overlapping window on every run. With `10`, each run asks
-SAP for everything changed since *today minus 10 days*. The pointer sent is never
-newer than the stored one, so a schedule that is behind still resumes from where
-it left off rather than skipping the gap - the window is always a superset of what
-the run would have fetched otherwise.
+Set Date Start to re-fetch changes since a given date on every run. It accepts an
+absolute date (`2026-01-01`) or a relative one (`10 days ago`, `2 weeks ago`). With
+`10 days ago`, each run asks SAP for everything changed since *today minus 10 days*.
 
-The pointer written back to state after the run is unaffected by the lookback: it
-never moves backwards, so the window stays anchored to the current date instead of
-creeping further back run after run.
+**The window always runs from Date Start up to now** - there is currently no end
+date, so every run fetches through to the present moment. (SAP's delta interface
+takes only a lower bound, so an upper bound cannot be offered yet.) Leave Date Start
+empty to simply resume from the last delta pointer.
+
+The pointer sent is never newer than the stored one, so a schedule that is behind
+still resumes from where it left off rather than skipping the gap - the window is
+always a superset of what the run would have fetched otherwise. The pointer written
+back to state never moves backwards, so the window stays anchored to the current
+date instead of creeping wider run after run.
 
 Two requirements, both enforced with a clear error rather than silently ignored:
 
@@ -70,12 +75,12 @@ Two requirements, both enforced with a clear error rather than silently ignored:
   rows are updated rather than appended as duplicates.
 
 Keep the window narrow. A delta fetch is a single un-paginated request, so the whole
-window has to come back in one response inside the configured `timeout`. The maximum
-accepted is 365 days, and anything above 31 logs a warning.
+window has to come back in one response inside the configured `timeout`; a window
+wider than 31 days logs a warning.
 
-The option only applies to `incremental_sync`. On a `full_sync` row, or on the first
+Date Start applies only to `incremental_sync`. On a `full_sync` row, or on the first
 run of an incremental row where no pointer has been stored yet, it is inert - the run
-behaves exactly as it would with the option unset.
+behaves exactly as it would with Date Start empty.
 
 Combining it with `full_load` only logs a warning - every run still overwrites the
 destination table with just the fetched window.

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -78,6 +78,20 @@
           "uniqueItems": true,
           "description": "DataSource pagination method",
           "propertyOrder": 5
+        },
+        "delta_lookback_days": {
+          "type": "integer",
+          "title": "Delta lookback (days)",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 3650,
+          "description": "Re-fetch an overlapping window on every incremental run instead of resuming exactly where the last run stopped. With 10, each run asks SAP for everything changed since today minus 10 days. Use it for tables whose changes cannot be tracked reliably. Leave at 0 to resume from the last delta pointer. Requires a source with a timestamp delta pointer (YYYYMMDD or YYYYMMDDHHMMSS) and, with Incremental Load, a primary key - the run fails with an explanation if either is missing.",
+          "options": {
+            "dependencies": {
+              "sync_type": "incremental_sync"
+            }
+          },
+          "propertyOrder": 6
         }
       }
     },

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -79,14 +79,12 @@
           "description": "DataSource pagination method",
           "propertyOrder": 5
         },
-        "delta_lookback_days": {
-          "type": "integer",
-          "title": "Delta lookback (days)",
-          "minimum": 0,
-          "maximum": 365,
-          "description": "Re-fetch changes from this many days back on every run, instead of resuming from the last delta pointer.",
+        "date_from": {
+          "type": "string",
+          "title": "Date Start",
+          "description": "Re-fetch changes since this date on every run, instead of resuming from the last delta pointer. Leave empty to resume from the last delta pointer.",
           "options": {
-            "tooltip": "Use this for source tables whose changes cannot be tracked reliably. With `10`, each run asks SAP for everything changed since today minus 10 days. Leave empty (or `0`) to resume from the last delta pointer.\n\nThe pointer stored between runs is unaffected, so the window stays anchored to the current date rather than creeping further back. A run that is behind schedule still resumes from where it left off, so no data is skipped.\n\nRequirements, both reported as a clear error if unmet:\n\n- The source's delta pointer must be a `YYYYMMDD` or `YYYYMMDDHHMMSS` timestamp. Sequential ids cannot express a date window.\n- With Incremental Load, SAP must report key columns for the table, so re-fetched rows are updated rather than appended as duplicates.\n\nKeep the window narrow: a delta fetch is a single un-paginated request, so the whole window must return in one response within the configured timeout.",
+            "tooltip": "Use this for source tables whose changes cannot be tracked reliably. Accepts an absolute date (`2026-01-01`) or a relative one (`10 days ago`, `2 weeks ago`). With `10 days ago`, each run asks SAP for everything changed since today minus 10 days.\n\n**The window always runs from this date up to now** - there is currently no end date, so every run fetches through to the present moment. Leave empty to simply resume from the last delta pointer.\n\nThe pointer stored between runs is never moved backwards, so the window stays anchored to the current date rather than creeping wider. A run that is behind schedule still resumes from where it left off, so no data is skipped. Date Start applies once the source has been synced at least once; the very first run (with no stored data yet) performs a full sync.\n\nRequirements, both reported as a clear error if unmet:\n\n- The source's delta pointer must be a `YYYYMMDD` or `YYYYMMDDHHMMSS` timestamp. Sequential ids cannot express a date window.\n- With Incremental Load, SAP must report key columns for the table, so re-fetched rows are updated rather than appended as duplicates.\n\nKeep the window narrow: a delta fetch is a single un-paginated request, so the whole window must return in one response within the configured timeout.",
             "dependencies": {
               "sync_type": "incremental_sync"
             }

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -84,8 +84,8 @@
           "title": "Delta lookback (days)",
           "default": 0,
           "minimum": 0,
-          "maximum": 3650,
-          "description": "Re-fetch an overlapping window on every incremental run instead of resuming exactly where the last run stopped. With 10, each run asks SAP for everything changed since today minus 10 days. Use it for tables whose changes cannot be tracked reliably. Leave at 0 to resume from the last delta pointer. Requires a source with a timestamp delta pointer (YYYYMMDD or YYYYMMDDHHMMSS) and, with Incremental Load, a primary key - the run fails with an explanation if either is missing.",
+          "maximum": 365,
+          "description": "Re-fetch an overlapping window on every incremental run instead of resuming exactly where the last run stopped. With 10, each run asks SAP for everything changed since today minus 10 days. Use it for tables whose changes cannot be tracked reliably. Leave at 0 to resume from the last delta pointer. A delta fetch is a single un-paginated request, so keep the window as narrow as the source needs. Requires a source with a timestamp delta pointer (YYYYMMDD or YYYYMMDDHHMMSS) and, with Incremental Load, a primary key - the run fails with an explanation if either is missing.",
           "options": {
             "dependencies": {
               "sync_type": "incremental_sync"

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -82,11 +82,11 @@
         "delta_lookback_days": {
           "type": "integer",
           "title": "Delta lookback (days)",
-          "default": 0,
           "minimum": 0,
           "maximum": 365,
-          "description": "Re-fetch an overlapping window on every incremental run instead of resuming exactly where the last run stopped. With 10, each run asks SAP for everything changed since today minus 10 days. Use it for tables whose changes cannot be tracked reliably. Leave at 0 to resume from the last delta pointer. A delta fetch is a single un-paginated request, so keep the window as narrow as the source needs. Requires a source with a timestamp delta pointer (YYYYMMDD or YYYYMMDDHHMMSS) and, with Incremental Load, a primary key - the run fails with an explanation if either is missing.",
+          "description": "Re-fetch changes from this many days back on every run, instead of resuming from the last delta pointer.",
           "options": {
+            "tooltip": "Use this for source tables whose changes cannot be tracked reliably. With `10`, each run asks SAP for everything changed since today minus 10 days. Leave empty (or `0`) to resume from the last delta pointer.\n\nThe pointer stored between runs is unaffected, so the window stays anchored to the current date rather than creeping further back. A run that is behind schedule still resumes from where it left off, so no data is skipped.\n\nRequirements, both reported as a clear error if unmet:\n\n- The source's delta pointer must be a `YYYYMMDD` or `YYYYMMDDHHMMSS` timestamp. Sequential ids cannot express a date window.\n- With Incremental Load, SAP must report key columns for the table, so re-fetched rows are updated rather than appended as duplicates.\n\nKeep the window narrow: a delta fetch is a single un-paginated request, so the whole window must return in one response within the configured timeout.",
             "dependencies": {
               "sync_type": "incremental_sync"
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 keboola.component==1.4.3
 keboola.utils
-keboola.http-client==1.2.0
+keboola.http-client>=1.2.0
 keboola.csvwriter
 mock
 freezegun

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 keboola.component==1.4.3
 keboola.utils
-git+https://github.com/keboola/python-http-client.git@feature/async
+keboola.http-client==1.2.0
 keboola.csvwriter
 mock
 freezegun

--- a/src/component.py
+++ b/src/component.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Union
 
 from keboola.component.base import ComponentBase, sync_action
@@ -11,21 +11,21 @@ from keboola.component.dao import TableDefinition
 from keboola.component.exceptions import UserException
 from keboola.component.sync_actions import SelectElement
 from keboola.csvwriter import ElasticDictWriter
+from keboola.utils import parse_datetime_interval
 
 from configuration import Configuration, ConfigurationBase, SyncActionConfiguration
 from sap_client.client import SAPClient, SapClientException
 from sap_client.sap_snowflake_mapping import SAP_TO_SNOWFLAKE_MAP
 
-# Delta pointer formats that a lookback window can be expressed in. The format is dictated by the
+# Delta pointer formats that a Date Start window can be expressed in. The format is dictated by the
 # SAP source, so it is inferred from the pointer already stored in state.
 DELTA_POINTER_FORMATS = {8: "%Y%m%d", 14: "%Y%m%d%H%M%S"}
 # Guards against sequential id pointers that happen to parse as a date (e.g. 10000101 -> year 1000).
 MIN_DELTA_POINTER_YEAR = 1990
 # A delta fetch is a single un-paginated request, so the whole window has to come back in one
-# response within the configured timeout. The cap keeps a typo from turning into a de-facto
-# full sync; the warning threshold flags windows wide enough to be worth thinking about.
-MAX_DELTA_LOOKBACK_DAYS = 365
-WIDE_DELTA_LOOKBACK_DAYS = 31
+# response within the configured timeout. A window wider than this is flagged, not blocked - a
+# one-off backfill from an absolute date is a legitimate (if heavy) use.
+WIDE_WINDOW_DAYS = 31
 
 
 class Component(ComponentBase):
@@ -53,7 +53,7 @@ class Component(ComponentBase):
         batch_size = self._configuration.source.batch_size
         paging_method = self._configuration.source.paging_method
         sync_type = self._configuration.source.sync_type
-        delta_lookback_days = self._validate_delta_lookback_days(self._configuration.source.delta_lookback_days)
+        date_from = self._configuration.source.date_from
 
         output_table_name = self._configuration.destination.output_table_name
         load_type = self._configuration.destination.load_type
@@ -68,13 +68,19 @@ class Component(ComponentBase):
 
         # The field is hidden in the UI outside incremental sync, so a leftover value on a full sync
         # row must stay inert - it cannot be cleared by someone who cannot see it.
-        lookback_enabled = bool(delta_lookback_days) and sync_type == "incremental_sync"
+        date_from_enabled = bool(date_from) and sync_type == "incremental_sync"
 
-        # The lookback only moves the pointer *sent* to SAP; stored_delta_max stays the floor for
-        # what is written back to state at the end of the run.
+        if date_from_enabled:
+            # Fail before any fetch on a Date Start that cannot be understood, even on a first run
+            # where it is not applied yet.
+            self._validate_date_from(date_from)
+
+        # Date Start only moves the pointer *sent* to SAP; stored_delta_max stays the floor for what
+        # is written back to state at the end of the run. It needs a stored pointer to learn the
+        # source's pointer format, so the very first run (no stored pointer) still does a full sync.
         previous_delta_max = stored_delta_max
-        if lookback_enabled and stored_delta_max:
-            previous_delta_max = self._apply_delta_lookback(stored_delta_max, delta_lookback_days)
+        if date_from_enabled and stored_delta_max:
+            previous_delta_max = self._apply_date_from(stored_delta_max, date_from)
 
         client = SAPClient(
             server_url=server_url,
@@ -93,18 +99,10 @@ class Component(ComponentBase):
         output_table_name = output_table_name or resource_alias
         incremental = load_type != "full_load"
 
-        if lookback_enabled and delta_lookback_days > WIDE_DELTA_LOOKBACK_DAYS:
+        if date_from_enabled and not incremental:
             logging.warning(
-                f"Delta lookback (days) is set to {delta_lookback_days}. A delta fetch is a single "
-                f"un-paginated request, so the whole window must be returned in one response within "
-                f"the configured timeout of {timeout}s. Use the narrowest window that covers the "
-                f"changes this source reports late."
-            )
-
-        if lookback_enabled and not incremental:
-            logging.warning(
-                f"Delta lookback (days) is set to {delta_lookback_days}, but the load type is Full Load, "
-                f"so every run overwrites the destination table with just the fetched window. "
+                f"Date Start is set to '{date_from}', but the load type is Full Load, so every run "
+                f"overwrites the destination table with just the fetched window. "
                 f"Use Incremental Load to keep the previously fetched data."
             )
 
@@ -122,8 +120,8 @@ class Component(ComponentBase):
             else:
                 raise UserException(f"An error occurred while fetching resource: {e}")
 
-        if lookback_enabled and incremental:
-            self._check_lookback_has_primary_key(client, resource_alias, delta_lookback_days)
+        if date_from_enabled and incremental:
+            self._check_date_from_has_primary_key(client, resource_alias)
 
         files = os.listdir(temp_dir)
 
@@ -169,23 +167,21 @@ class Component(ComponentBase):
         return previous_delta_max
 
     @staticmethod
-    def _validate_delta_lookback_days(lookback_days: int) -> int:
-        """Validates the lookback window at the start of the run, before any branch can skip it."""
-        if isinstance(lookback_days, bool) or not isinstance(lookback_days, int):
-            raise UserException(f"Delta lookback (days) must be a whole number, got '{lookback_days}'.")
-
-        if not 0 <= lookback_days <= MAX_DELTA_LOOKBACK_DAYS:
+    def _validate_date_from(date_from: str) -> None:
+        """Fails fast on a Date Start that cannot be understood, before any fetch happens."""
+        try:
+            parse_datetime_interval(date_from, "now")
+        except (TypeError, ValueError) as e:
             raise UserException(
-                f"Delta lookback (days) must be between 0 and {MAX_DELTA_LOOKBACK_DAYS}, got {lookback_days}."
+                f"Could not understand Date Start '{date_from}'. Use an absolute date "
+                f"(for example 2026-01-01) or a relative one (for example '10 days ago'). ({e})"
             )
-
-        return lookback_days
 
     @staticmethod
     def _parse_delta_pointer(delta_pointer: Union[int, str], now: datetime) -> tuple[datetime, str] | None:
         """Parses a delta pointer as a timestamp.
 
-        Returns a (datetime, format) tuple, or None when the pointer is not a timestamp a lookback
+        Returns a (datetime, format) tuple, or None when the pointer is not a timestamp a Date Start
         window can be expressed in - a sequential id, for instance. The year range check keeps
         sequential ids that happen to parse as a date (10000101 -> year 1000) out of the timestamp
         branch, where they would be silently corrupted.
@@ -207,45 +203,52 @@ class Component(ComponentBase):
         return parsed, date_format
 
     @classmethod
-    def _apply_delta_lookback(
-        cls, delta_pointer: Union[int, str], lookback_days: int, now: datetime | None = None
-    ) -> Union[int, str]:
-        """Moves the delta pointer sent to SAP back to `now - lookback_days`.
+    def _apply_date_from(cls, delta_pointer: Union[int, str], date_from: str) -> Union[int, str]:
+        """Moves the delta pointer sent to SAP back to the Date Start, rendered in the source's format.
 
-        The pointer returned is never newer than the stored one, so the window fetched is always a
-        superset of what the run would fetch without the lookback: a schedule that is behind still
-        resumes from where it left off instead of skipping the gap.
+        `date_from` is a relative ("10 days ago") or absolute ("2026-01-01") date, always resolved
+        against the current time - the window has no upper bound, it runs to now. The pointer
+        returned is never newer than the stored one (min), so the window fetched is always a
+        superset of what the run would fetch without it: a schedule that is behind still resumes
+        from where it left off instead of skipping the gap.
         """
-        now = now or datetime.now()
-        parsed = cls._parse_delta_pointer(delta_pointer, now)
+        start_dt, now_dt = parse_datetime_interval(date_from, "now")
+        parsed = cls._parse_delta_pointer(delta_pointer, now_dt)
 
         if parsed is None:
             raise UserException(
-                f"Delta lookback (days) is set to {lookback_days}, but the delta pointer stored for this "
-                f"source ({delta_pointer}) is not a timestamp. Only YYYYMMDD and YYYYMMDDHHMMSS delta "
-                f"pointers can be shifted; set Delta lookback (days) to 0 for this source."
+                f"Date Start is set to '{date_from}', but the delta pointer stored for this source "
+                f"({delta_pointer}) is not a timestamp. Date Start only works when the source's delta "
+                f"pointer is a YYYYMMDD or YYYYMMDDHHMMSS timestamp; clear Date Start for this source."
             )
 
         stored_datetime, date_format = parsed
-        shifted = min(stored_datetime, now - timedelta(days=lookback_days))
+        shifted = min(stored_datetime, start_dt)
         new_pointer = shifted.strftime(date_format)
+
+        if (now_dt - shifted).days > WIDE_WINDOW_DAYS:
+            logging.warning(
+                f"Date Start '{date_from}' fetches roughly {(now_dt - shifted).days} days in one "
+                f"un-paginated request, which must return in a single response within the configured "
+                f"timeout. Use the narrowest window that covers the changes this source reports late."
+            )
 
         if shifted == stored_datetime:
             logging.info(
-                f"The stored delta pointer {delta_pointer} is already older than the {lookback_days} "
-                f"day(s) lookback window, so it is used unchanged and no data is skipped."
+                f"The stored delta pointer {delta_pointer} is already older than Date Start "
+                f"'{date_from}', so it is used unchanged and no data is skipped."
             )
         else:
             logging.info(
-                f"Delta lookback of {lookback_days} day(s) moved the delta pointer sent to SAP "
+                f"Date Start '{date_from}' moved the delta pointer sent to SAP "
                 f"from {delta_pointer} to {new_pointer}."
             )
 
         return int(new_pointer) if isinstance(delta_pointer, int) else new_pointer
 
     @staticmethod
-    def _check_lookback_has_primary_key(client: SAPClient, resource_alias: str, lookback_days: int) -> None:
-        """Refuses a lookback window that would append the re-fetched rows as duplicates.
+    def _check_date_from_has_primary_key(client: SAPClient, resource_alias: str) -> None:
+        """Refuses a Date Start window that would append the re-fetched rows as duplicates.
 
         Checked against the column metadata rather than the written table so that the outcome
         depends only on the configuration and the source, not on whether this particular run
@@ -261,10 +264,9 @@ class Component(ComponentBase):
         )
 
         raise UserException(
-            f"Delta lookback (days) is set to {lookback_days}, but {reason} for resource "
-            f"{resource_alias}. Without a primary key the re-fetched rows would be appended to the "
-            f"destination table instead of updated, creating duplicates on every run. "
-            f"Set Delta lookback (days) to 0 for this source."
+            f"Date Start is set, but {reason} for resource {resource_alias}. Without a primary key "
+            f"the re-fetched rows would be appended to the destination table instead of updated, "
+            f"creating duplicates on every run. Clear Date Start for this source."
         )
 
     @staticmethod
@@ -273,10 +275,10 @@ class Component(ComponentBase):
     ) -> Union[int, str, None]:
         """The delta pointer written back to state, floored by the one the run started from.
 
-        A lookback shifts the pointer sent to SAP, and the client seeds its own maximum with that
-        shifted value. Without this floor a run that returns no delta pointer of its own (nothing
-        changed since the last run) would persist the shifted value, and the next run would shift
-        that again - walking the window backwards a little further every run.
+        Date Start moves the pointer sent to SAP back, and the client seeds its own maximum with
+        that moved value. Without this floor a run that returns no delta pointer of its own (nothing
+        changed since the last run) would persist the moved value, and the window would then creep
+        wider every run.
         """
         candidates = [value for value in (max_delta_pointer, stored_delta_max) if value]
 

--- a/src/component.py
+++ b/src/component.py
@@ -3,7 +3,8 @@ import json
 import logging
 import os
 import shutil
-from typing import Union
+from datetime import datetime, timedelta
+from typing import Optional, Tuple, Union
 
 from keboola.component.base import ComponentBase, sync_action
 from keboola.component.dao import TableDefinition
@@ -14,6 +15,13 @@ from keboola.csvwriter import ElasticDictWriter
 from configuration import Configuration, ConfigurationBase, SyncActionConfiguration
 from sap_client.client import SAPClient, SapClientException
 from sap_client.sap_snowflake_mapping import SAP_TO_SNOWFLAKE_MAP
+
+# Delta pointer formats that a lookback window can be expressed in. The format is dictated by the
+# SAP source, so it is inferred from the pointer already stored in state.
+DELTA_POINTER_FORMATS = {8: "%Y%m%d", 14: "%Y%m%d%H%M%S"}
+# Guards against sequential id pointers that happen to parse as a date (e.g. 10000101 -> year 1000).
+MIN_DELTA_POINTER_YEAR = 1990
+MAX_DELTA_LOOKBACK_DAYS = 3650
 
 
 class Component(ComponentBase):
@@ -41,6 +49,7 @@ class Component(ComponentBase):
         batch_size = self._configuration.source.batch_size
         paging_method = self._configuration.source.paging_method
         sync_type = self._configuration.source.sync_type
+        delta_lookback_days = self._validate_delta_lookback_days(self._configuration.source.delta_lookback_days)
 
         output_table_name = self._configuration.destination.output_table_name
         load_type = self._configuration.destination.load_type
@@ -51,7 +60,13 @@ class Component(ComponentBase):
 
         statefile_columns = self.state.get(resource_alias, {}).get("columns", [])
 
-        previous_delta_max = self._init_delta(sync_type, resource_alias)
+        stored_delta_max = self._init_delta(sync_type, resource_alias)
+
+        # The lookback only moves the pointer *sent* to SAP; stored_delta_max stays the floor for
+        # what is written back to state at the end of the run.
+        previous_delta_max = stored_delta_max
+        if stored_delta_max and delta_lookback_days:
+            previous_delta_max = self._apply_delta_lookback(stored_delta_max, delta_lookback_days)
 
         client = SAPClient(
             server_url=server_url,
@@ -69,6 +84,13 @@ class Component(ComponentBase):
 
         output_table_name = output_table_name or resource_alias
         incremental = load_type != "full_load"
+
+        if delta_lookback_days and not incremental:
+            logging.warning(
+                f"Delta lookback (days) is set to {delta_lookback_days}, but the load type is Full Load, "
+                f"so every run overwrites the destination table with just the fetched window. "
+                f"Use Incremental Load to keep the previously fetched data."
+            )
 
         out_table = self.create_out_table_definition(name=output_table_name, incremental=incremental)
 
@@ -97,6 +119,15 @@ class Component(ComponentBase):
                             wr.writerow(self._ensure_proper_column_names(row))
 
             out_table = self.add_column_metadata(client, out_table)
+
+            if delta_lookback_days and incremental and not out_table.primary_key:
+                raise UserException(
+                    f"Delta lookback (days) is set to {delta_lookback_days}, but SAP reports no key columns "
+                    f"for resource {resource_alias}. Without a primary key the re-fetched rows would be "
+                    f"appended to the destination table instead of updated, creating duplicates. "
+                    f"Set Delta lookback (days) to 0 for this source."
+                )
+
             self.write_manifest(out_table)
 
             self.state.setdefault(resource_alias, {})["columns"] = wr.fieldnames
@@ -106,9 +137,9 @@ class Component(ComponentBase):
         else:
             logging.warning(f"No data were fetched for resource {resource_alias}.")
 
-        max_delta_pointer = client.max_delta_pointer
+        max_delta_pointer = self._persisted_delta_pointer(client.max_delta_pointer, stored_delta_max)
         if max_delta_pointer:
-            self.state[resource_alias]["delta_max"] = max_delta_pointer
+            self.state.setdefault(resource_alias, {})["delta_max"] = max_delta_pointer
             logging.info(f"Delta pointer for resource {resource_alias} was set to {max_delta_pointer}.")
 
         self.write_state_file(self.state)
@@ -126,6 +157,99 @@ class Component(ComponentBase):
                 )
 
         return previous_delta_max
+
+    @staticmethod
+    def _validate_delta_lookback_days(lookback_days: int) -> int:
+        """Validates the lookback window at the start of the run, before any branch can skip it."""
+        if isinstance(lookback_days, bool) or not isinstance(lookback_days, int):
+            raise UserException(f"Delta lookback (days) must be a whole number, got '{lookback_days}'.")
+
+        if not 0 <= lookback_days <= MAX_DELTA_LOOKBACK_DAYS:
+            raise UserException(
+                f"Delta lookback (days) must be between 0 and {MAX_DELTA_LOOKBACK_DAYS}, got {lookback_days}."
+            )
+
+        return lookback_days
+
+    @staticmethod
+    def _parse_delta_pointer(delta_pointer: Union[int, str], now: datetime) -> Optional[Tuple[datetime, str]]:
+        """Parses a delta pointer as a timestamp.
+
+        Returns a (datetime, format) tuple, or None when the pointer is not a timestamp a lookback
+        window can be expressed in - a sequential id, for instance. The year range check keeps
+        sequential ids that happen to parse as a date (10000101 -> year 1000) out of the timestamp
+        branch, where they would be silently corrupted.
+        """
+        pointer = str(delta_pointer)
+        date_format = DELTA_POINTER_FORMATS.get(len(pointer))
+
+        if not date_format or not pointer.isdigit():
+            return None
+
+        try:
+            parsed = datetime.strptime(pointer, date_format)
+        except ValueError:
+            return None
+
+        if not MIN_DELTA_POINTER_YEAR <= parsed.year <= now.year + 1:
+            return None
+
+        return parsed, date_format
+
+    @classmethod
+    def _apply_delta_lookback(
+        cls, delta_pointer: Union[int, str], lookback_days: int, now: datetime = None
+    ) -> Union[int, str]:
+        """Moves the delta pointer sent to SAP back to `now - lookback_days`.
+
+        The pointer returned is never newer than the stored one, so the window fetched is always a
+        superset of what the run would fetch without the lookback: a schedule that is behind still
+        resumes from where it left off instead of skipping the gap.
+        """
+        now = now or datetime.now()
+        parsed = cls._parse_delta_pointer(delta_pointer, now)
+
+        if parsed is None:
+            raise UserException(
+                f"Delta lookback (days) is set to {lookback_days}, but the delta pointer stored for this "
+                f"source ({delta_pointer}) is not a timestamp. Only YYYYMMDD and YYYYMMDDHHMMSS delta "
+                f"pointers can be shifted; set Delta lookback (days) to 0 for this source."
+            )
+
+        stored_datetime, date_format = parsed
+        shifted = min(stored_datetime, now - timedelta(days=lookback_days))
+        new_pointer = shifted.strftime(date_format)
+
+        if shifted == stored_datetime:
+            logging.info(
+                f"Delta lookback of {lookback_days} day(s) reaches further back than the stored delta "
+                f"pointer {delta_pointer}, which is used unchanged so that no data is skipped."
+            )
+        else:
+            logging.info(
+                f"Delta lookback of {lookback_days} day(s) moved the delta pointer sent to SAP "
+                f"from {delta_pointer} to {new_pointer}."
+            )
+
+        return int(new_pointer) if isinstance(delta_pointer, int) else new_pointer
+
+    @staticmethod
+    def _persisted_delta_pointer(
+        max_delta_pointer: Union[int, str, None], stored_delta_max: Union[int, str, None]
+    ) -> Union[int, str, None]:
+        """The delta pointer written back to state, floored by the one the run started from.
+
+        A lookback shifts the pointer sent to SAP, and the client seeds its own maximum with that
+        shifted value. Without this floor a run that returns no delta pointer of its own (nothing
+        changed since the last run) would persist the shifted value, and the next run would shift
+        that again - walking the window backwards a little further every run.
+        """
+        candidates = [value for value in (max_delta_pointer, stored_delta_max) if value]
+
+        if not candidates:
+            return None
+
+        return SAPClient.max_timestamp_or_id(candidates)
 
     @staticmethod
     def add_column_metadata(client: SAPClient, out_table: TableDefinition):

--- a/src/component.py
+++ b/src/component.py
@@ -21,7 +21,11 @@ from sap_client.sap_snowflake_mapping import SAP_TO_SNOWFLAKE_MAP
 DELTA_POINTER_FORMATS = {8: "%Y%m%d", 14: "%Y%m%d%H%M%S"}
 # Guards against sequential id pointers that happen to parse as a date (e.g. 10000101 -> year 1000).
 MIN_DELTA_POINTER_YEAR = 1990
-MAX_DELTA_LOOKBACK_DAYS = 3650
+# A delta fetch is a single un-paginated request, so the whole window has to come back in one
+# response within the configured timeout. The cap keeps a typo from turning into a de-facto
+# full sync; the warning threshold flags windows wide enough to be worth thinking about.
+MAX_DELTA_LOOKBACK_DAYS = 365
+WIDE_DELTA_LOOKBACK_DAYS = 31
 
 
 class Component(ComponentBase):
@@ -62,10 +66,14 @@ class Component(ComponentBase):
 
         stored_delta_max = self._init_delta(sync_type, resource_alias)
 
+        # The field is hidden in the UI outside incremental sync, so a leftover value on a full sync
+        # row must stay inert - it cannot be cleared by someone who cannot see it.
+        lookback_enabled = bool(delta_lookback_days) and sync_type == "incremental_sync"
+
         # The lookback only moves the pointer *sent* to SAP; stored_delta_max stays the floor for
         # what is written back to state at the end of the run.
         previous_delta_max = stored_delta_max
-        if stored_delta_max and delta_lookback_days:
+        if lookback_enabled and stored_delta_max:
             previous_delta_max = self._apply_delta_lookback(stored_delta_max, delta_lookback_days)
 
         client = SAPClient(
@@ -85,7 +93,15 @@ class Component(ComponentBase):
         output_table_name = output_table_name or resource_alias
         incremental = load_type != "full_load"
 
-        if delta_lookback_days and not incremental:
+        if lookback_enabled and delta_lookback_days > WIDE_DELTA_LOOKBACK_DAYS:
+            logging.warning(
+                f"Delta lookback (days) is set to {delta_lookback_days}. A delta fetch is a single "
+                f"un-paginated request, so the whole window must be returned in one response within "
+                f"the configured timeout of {timeout}s. Use the narrowest window that covers the "
+                f"changes this source reports late."
+            )
+
+        if lookback_enabled and not incremental:
             logging.warning(
                 f"Delta lookback (days) is set to {delta_lookback_days}, but the load type is Full Load, "
                 f"so every run overwrites the destination table with just the fetched window. "
@@ -106,6 +122,9 @@ class Component(ComponentBase):
             else:
                 raise UserException(f"An error occurred while fetching resource: {e}")
 
+        if lookback_enabled and incremental:
+            self._check_lookback_has_primary_key(client, resource_alias, delta_lookback_days)
+
         files = os.listdir(temp_dir)
 
         if files:
@@ -119,15 +138,6 @@ class Component(ComponentBase):
                             wr.writerow(self._ensure_proper_column_names(row))
 
             out_table = self.add_column_metadata(client, out_table)
-
-            if delta_lookback_days and incremental and not out_table.primary_key:
-                raise UserException(
-                    f"Delta lookback (days) is set to {delta_lookback_days}, but SAP reports no key columns "
-                    f"for resource {resource_alias}. Without a primary key the re-fetched rows would be "
-                    f"appended to the destination table instead of updated, creating duplicates. "
-                    f"Set Delta lookback (days) to 0 for this source."
-                )
-
             self.write_manifest(out_table)
 
             self.state.setdefault(resource_alias, {})["columns"] = wr.fieldnames
@@ -232,6 +242,24 @@ class Component(ComponentBase):
             )
 
         return int(new_pointer) if isinstance(delta_pointer, int) else new_pointer
+
+    @staticmethod
+    def _check_lookback_has_primary_key(client: SAPClient, resource_alias: str, lookback_days: int) -> None:
+        """Refuses a lookback window that would append the re-fetched rows as duplicates.
+
+        Checked against the column metadata rather than the written table so that the outcome
+        depends only on the configuration and the source, not on whether this particular run
+        happened to return any rows.
+        """
+        if any(column.get("KEY") for column in client.metadata.values()):
+            return
+
+        raise UserException(
+            f"Delta lookback (days) is set to {lookback_days}, but SAP reports no key columns for "
+            f"resource {resource_alias}. Without a primary key the re-fetched rows would be appended "
+            f"to the destination table instead of updated, creating duplicates on every run. "
+            f"Set Delta lookback (days) to 0 for this source."
+        )
 
     @staticmethod
     def _persisted_delta_pointer(

--- a/src/component.py
+++ b/src/component.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 from datetime import datetime, timedelta
-from typing import Optional, Tuple, Union
+from typing import Union
 
 from keboola.component.base import ComponentBase, sync_action
 from keboola.component.dao import TableDefinition
@@ -182,7 +182,7 @@ class Component(ComponentBase):
         return lookback_days
 
     @staticmethod
-    def _parse_delta_pointer(delta_pointer: Union[int, str], now: datetime) -> Optional[Tuple[datetime, str]]:
+    def _parse_delta_pointer(delta_pointer: Union[int, str], now: datetime) -> tuple[datetime, str] | None:
         """Parses a delta pointer as a timestamp.
 
         Returns a (datetime, format) tuple, or None when the pointer is not a timestamp a lookback
@@ -208,7 +208,7 @@ class Component(ComponentBase):
 
     @classmethod
     def _apply_delta_lookback(
-        cls, delta_pointer: Union[int, str], lookback_days: int, now: datetime = None
+        cls, delta_pointer: Union[int, str], lookback_days: int, now: datetime | None = None
     ) -> Union[int, str]:
         """Moves the delta pointer sent to SAP back to `now - lookback_days`.
 
@@ -232,8 +232,8 @@ class Component(ComponentBase):
 
         if shifted == stored_datetime:
             logging.info(
-                f"Delta lookback of {lookback_days} day(s) reaches further back than the stored delta "
-                f"pointer {delta_pointer}, which is used unchanged so that no data is skipped."
+                f"The stored delta pointer {delta_pointer} is already older than the {lookback_days} "
+                f"day(s) lookback window, so it is used unchanged and no data is skipped."
             )
         else:
             logging.info(
@@ -254,10 +254,16 @@ class Component(ComponentBase):
         if any(column.get("KEY") for column in client.metadata.values()):
             return
 
+        reason = (
+            "SAP returned no column metadata at all"
+            if not client.metadata
+            else "SAP reports no key columns"
+        )
+
         raise UserException(
-            f"Delta lookback (days) is set to {lookback_days}, but SAP reports no key columns for "
-            f"resource {resource_alias}. Without a primary key the re-fetched rows would be appended "
-            f"to the destination table instead of updated, creating duplicates on every run. "
+            f"Delta lookback (days) is set to {lookback_days}, but {reason} for resource "
+            f"{resource_alias}. Without a primary key the re-fetched rows would be appended to the "
+            f"destination table instead of updated, creating duplicates on every run. "
             f"Set Delta lookback (days) to 0 for this source."
         )
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -66,6 +66,7 @@ class Source(ConfigurationBase):
     paging_method: str
     limit: int = ConfigurationBase.DEFAULT_LIMIT
     batch_size: int = ConfigurationBase.DEFAULT_BATCH_SIZE
+    delta_lookback_days: int = 0
 
 
 @dataclass

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -66,7 +66,7 @@ class Source(ConfigurationBase):
     paging_method: str
     limit: int = ConfigurationBase.DEFAULT_LIMIT
     batch_size: int = ConfigurationBase.DEFAULT_BATCH_SIZE
-    delta_lookback_days: int = 0
+    date_from: str = ""
 
 
 @dataclass

--- a/src/sap_client/client.py
+++ b/src/sap_client/client.py
@@ -333,10 +333,10 @@ class SAPClient(AsyncHttpClient):
     @property
     def max_delta_pointer(self) -> Union[int, str, None]:
         logging.debug(f"Client Delta values: {self.delta_values}")
-        return self._max_timestamp_or_id(self.delta_values)
+        return self.max_timestamp_or_id(self.delta_values)
 
     @staticmethod
-    def _max_timestamp_or_id(values: list):
+    def max_timestamp_or_id(values: list):
         if not values:
             return None
         # sometimes can come different length of values, so we need to normalize them

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -167,16 +167,22 @@ class FakeSapClient(SAPClient):
     sent_pointers = []
     returned_pointer = None
     metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10, "KEY": True}}
+    rows = []
 
     def __init__(self, **kwargs):
         # Deliberately not calling super().__init__: it would build a real HTTP client.
         self.delta = kwargs.get("delta")
+        self.destination = kwargs.get("destination")
+        self.metadata = FakeSapClient.metadata
         self.delta_values = []
         if self.delta:
             self.delta_values.append(self.delta)
         FakeSapClient.sent_pointers.append(self.delta)
 
     async def fetch(self, resource_alias, paging_method):
+        if FakeSapClient.rows:
+            with open(os.path.join(self.destination, f"{resource_alias}_0.json"), "w") as f:
+                json.dump(FakeSapClient.rows, f)
         if FakeSapClient.returned_pointer:
             self.delta_values.append(FakeSapClient.returned_pointer)
 
@@ -194,6 +200,7 @@ class TestDeltaLookbackRun(unittest.TestCase):
         FakeSapClient.sent_pointers = []
         FakeSapClient.returned_pointer = None
         FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10, "KEY": True}}
+        FakeSapClient.rows = []
 
     def tearDown(self):
         shutil.rmtree(self.data_dir, ignore_errors=True)
@@ -263,13 +270,38 @@ class TestDeltaLookbackRun(unittest.TestCase):
         self.assertEqual(20260806021626, self._read_state()[self.ALIAS]["delta_max"])
 
     @freeze_time("2026-08-06 02:16:26")
-    def test_run_fails_when_lookback_source_has_no_primary_key(self):
+    def test_run_writes_the_table_with_lookback_enabled(self):
         self._write_config(delta_lookback_days=10)
         self._write_state(self.STORED)
+        FakeSapClient.rows = [{"ACC_NUMBER": "1"}, {"ACC_NUMBER": "2"}]
+
+        self._run()
+
+        table_path = os.path.join(self.data_dir, "out", "tables", self.ALIAS)
+        self.assertTrue(os.path.exists(table_path))
+        self.assertTrue(os.path.exists(table_path + ".manifest"))
+        self.assertEqual(["ACC_NUMBER"], self._read_state()[self.ALIAS]["columns"])
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_run_fails_when_lookback_source_has_no_primary_key(self):
+        """The guard must run before anything is written, and regardless of how many rows came back."""
         FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
 
-        with self.assertRaises(UserException):
-            self._run()
+        for rows in ([], [{"ACC_NUMBER": "1"}]):
+            with self.subTest(rows=len(rows)):
+                self.setUp()
+                FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
+                FakeSapClient.rows = rows
+                self._write_config(delta_lookback_days=10)
+                self._write_state(self.STORED)
+
+                with self.assertRaises(UserException):
+                    self._run()
+
+                # Nothing written: no manifest, and the stored pointer is left alone.
+                table_path = os.path.join(self.data_dir, "out", "tables", self.ALIAS)
+                self.assertFalse(os.path.exists(table_path + ".manifest"))
+                self.assertFalse(os.path.exists(os.path.join(self.data_dir, "out", "state.json")))
 
     @freeze_time("2026-08-06 02:16:26")
     def test_full_sync_row_with_a_leftover_lookback_value_is_unaffected(self):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -9,13 +9,16 @@ import tempfile
 import unittest
 import mock
 import os
-from datetime import datetime
 from freezegun import freeze_time
 
 from keboola.component.exceptions import UserException
 
 from component import Component
 from sap_client.client import SAPClient
+
+# Chosen at midday so the local-timezone shift dateparser applies to relative dates
+# ("10 days ago") never crosses a day boundary, keeping date-level assertions stable in any timezone.
+FROZEN_NOW = "2026-08-06 12:00:00"
 
 
 class TestComponent(unittest.TestCase):
@@ -30,79 +33,74 @@ class TestComponent(unittest.TestCase):
             comp.run()
 
 
-class TestDeltaLookback(unittest.TestCase):
-    """Covers `source.delta_lookback_days` (SUPPORT-17281).
+@freeze_time(FROZEN_NOW)
+class TestDateFrom(unittest.TestCase):
+    """Covers `source.date_from` - the Date Start window (SUPPORT-17281).
 
-    NOW is the run time; STORED is a pointer the previous run left behind, one day old.
+    STORED is a 14-digit pointer a previous run left behind, one day before the frozen now.
     """
 
-    NOW = datetime(2026, 8, 6, 2, 16, 26)
     STORED = 20260805021626
-
-    def _shift(self, pointer, lookback_days, now=None):
-        return Component._apply_delta_lookback(pointer, lookback_days, now or self.NOW)
 
     # --- the pointer sent to SAP ------------------------------------------------
 
-    def test_sent_pointer_is_now_minus_lookback(self):
-        """The customer's ask: 10 days back from today, not from the stored pointer."""
-        self.assertEqual(20260727021626, self._shift(self.STORED, 10))
+    def test_absolute_date_from_moves_pointer_back(self):
+        """The customer's ask: fetch from a chosen date, not from the stored pointer."""
+        self.assertEqual(20260727021626, Component._apply_date_from(self.STORED, "2026-07-27 02:16:26"))
 
-    def test_sent_pointer_falls_back_to_stored_when_schedule_is_behind(self):
-        """A run that is behind must resume from the stored pointer, never skip the gap."""
+    def test_relative_date_from_is_now_minus_window(self):
+        """`10 days ago` from the frozen now (Aug 6) is Jul 27; assert the date, not the tz-shifted time."""
+        sent = Component._apply_date_from(self.STORED, "10 days ago")
+        self.assertEqual(20260727, sent // 1_000_000)
+        self.assertLessEqual(sent, self.STORED)
+
+    def test_date_from_falls_back_to_stored_when_schedule_is_behind(self):
+        """A run whose stored pointer is already older than Date Start must not skip the gap."""
         stored = 20260601000000
-        self.assertEqual(stored, self._shift(stored, 10))
-
-    def test_sent_pointer_is_never_newer_than_stored(self):
-        for lookback_days in (1, 5, 10, 365):
-            with self.subTest(lookback_days=lookback_days):
-                self.assertLessEqual(self._shift(self.STORED, lookback_days), self.STORED)
+        self.assertEqual(stored, Component._apply_date_from(stored, "2026-07-27"))
 
     def test_date_only_pointer_keeps_its_format(self):
-        self.assertEqual(20260727, self._shift(20260805, 10))
+        self.assertEqual(20260727, Component._apply_date_from(20260805, "2026-07-27"))
 
     def test_string_pointer_stays_a_string(self):
-        shifted = self._shift("20260805021626", 10)
-        self.assertEqual("20260727021626", shifted)
-        self.assertIsInstance(shifted, str)
+        sent = Component._apply_date_from("20260805021626", "2026-07-27")
+        self.assertEqual("20260727000000", sent)
+        self.assertIsInstance(sent, str)
 
-    def test_month_boundary(self):
-        now = datetime(2026, 3, 1)
-        self.assertEqual(20260228000000, self._shift(20260301000000, 1, now))
+    def test_sent_pointer_is_never_newer_than_stored(self):
+        for date_from in ("2026-07-27", "2026-08-01", "1 day ago", "2 weeks ago"):
+            with self.subTest(date_from=date_from):
+                self.assertLessEqual(Component._apply_date_from(self.STORED, date_from), self.STORED)
 
-    def test_leap_day(self):
-        now = datetime(2028, 3, 1)
-        self.assertEqual(20280229000000, self._shift(20280301000000, 1, now))
-
-    # --- pointers a lookback cannot be expressed on -----------------------------
+    # --- pointers a Date Start cannot be expressed on ---------------------------
 
     def test_sequential_id_pointer_raises(self):
         with self.assertRaises(UserException):
-            self._shift(12345, 10)
+            Component._apply_date_from(12345, "10 days ago")
 
     def test_date_like_sequential_id_raises_instead_of_being_corrupted(self):
-        """`10000101` parses as year 1000; shifting it would jump the id back by millions."""
+        """`10000101` parses as year 1000; treating it as a date would jump the id back by millions."""
         for pointer in (10000101, 12340101, 20260101021626000):
             with self.subTest(pointer=pointer):
                 with self.assertRaises(UserException):
-                    self._shift(pointer, 10)
+                    Component._apply_date_from(pointer, "10 days ago")
 
     def test_non_numeric_pointer_raises(self):
         with self.assertRaises(UserException):
-            self._shift("2026-08-05", 10)
+            Component._apply_date_from("2026-08-05", "10 days ago")
 
-    # --- validation --------------------------------------------------------------
+    # --- Date Start string validation --------------------------------------------
 
-    def test_invalid_lookback_values_raise(self):
-        for value in (-1, 366, 3650, True, "10"):
+    def test_unparseable_date_from_raises(self):
+        for value in ("garbage", "not a date", "next bluesday"):
             with self.subTest(value=value):
                 with self.assertRaises(UserException):
-                    Component._validate_delta_lookback_days(value)
+                    Component._validate_date_from(value)
 
-    def test_valid_lookback_values_accepted(self):
-        for value in (0, 10, 365):
+    def test_valid_date_from_accepted(self):
+        for value in ("2026-01-01", "10 days ago", "today", "2 weeks ago"):
             with self.subTest(value=value):
-                self.assertEqual(value, Component._validate_delta_lookback_days(value))
+                Component._validate_date_from(value)  # must not raise
 
     # --- what gets written back to state -----------------------------------------
 
@@ -110,14 +108,13 @@ class TestDeltaLookback(unittest.TestCase):
         """On a quiet run SAP returns no delta pointer, and the stored one must survive intact.
 
         The client seeds its own maximum with the pointer it was handed, so without the floor the
-        shifted pointer is what gets persisted: state drops back to the start of the lookback
-        window and stays there, and the window then widens by a day for every day that passes.
+        moved-back pointer is what gets persisted: state drops to the start of the window and stays
+        there, and the window then widens by a day for every day that passes.
         """
         stored = self.STORED
-        now = self.NOW
 
         for run in range(5):
-            sent = self._shift(stored, 10, now)
+            sent = Component._apply_date_from(stored, "10 days ago")
             # SAP reports nothing changed -> the client's max is the pointer it was given.
             persisted = Component._persisted_delta_pointer(sent, stored)
 
@@ -136,13 +133,12 @@ class TestDeltaLookback(unittest.TestCase):
         self.assertEqual(20260806021626, Component._persisted_delta_pointer(20260806021626, False))
         self.assertIsNone(Component._persisted_delta_pointer(None, False))
 
-    # --- unchanged behaviour when the option is not set ---------------------------
+    # --- unchanged behaviour when Date Start is not set ---------------------------
 
-    def test_unset_lookback_leaves_the_stored_pointer_untouched(self):
-        """With the option off, the pointer sent and the pointer persisted are both the stored one."""
-        state = {"ACC_DOC_HEADER": {"delta_max": self.STORED}}
+    def test_unset_date_from_leaves_the_stored_pointer_untouched(self):
+        """With Date Start empty, the pointer sent and the pointer persisted are both the stored one."""
         component = Component.__new__(Component)
-        component.state = state
+        component.state = {"ACC_DOC_HEADER": {"delta_max": self.STORED}}
 
         stored = component._init_delta("incremental_sync", "ACC_DOC_HEADER")
 
@@ -187,8 +183,9 @@ class FakeSapClient(SAPClient):
             self.delta_values.append(FakeSapClient.returned_pointer)
 
 
-class TestDeltaLookbackRun(unittest.TestCase):
-    """Drives the real `Component.run()` so the lookback wiring itself is covered, not just the helpers."""
+@freeze_time(FROZEN_NOW)
+class TestDateFromRun(unittest.TestCase):
+    """Drives the real `Component.run()` so the Date Start wiring itself is covered, not just the helpers."""
 
     ALIAS = "ACC_DOC_HEADER"
     STORED = 20260805021626
@@ -205,16 +202,18 @@ class TestDeltaLookbackRun(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.data_dir, ignore_errors=True)
 
-    def _write_config(self, delta_lookback_days=0, sync_type="incremental_sync", load_type="incremental_load"):
+    def _write_config(self, date_from="", sync_type="incremental_sync", load_type="incremental_load"):
+        source = {
+            "resource_alias": self.ALIAS,
+            "sync_type": sync_type,
+            "paging_method": "key",
+        }
+        if date_from:
+            source["date_from"] = date_from
         config = {
             "parameters": {
                 "authentication": {"server_url": "https://sap.example", "username": "u", "#password": "p"},
-                "source": {
-                    "resource_alias": self.ALIAS,
-                    "sync_type": sync_type,
-                    "paging_method": "key",
-                    "delta_lookback_days": delta_lookback_days,
-                },
+                "source": source,
                 "destination": {"output_table_name": "", "load_type": load_type},
             }
         }
@@ -234,14 +233,13 @@ class TestDeltaLookbackRun(unittest.TestCase):
             with mock.patch("component.SAPClient", FakeSapClient):
                 Component().run()
 
-    @freeze_time("2026-08-06 02:16:26")
-    def test_run_sends_lookback_pointer_but_persists_the_stored_one(self):
-        """The failure this guards against: a quiet run persisting the shifted pointer.
+    def test_run_sends_date_from_pointer_but_persists_the_stored_one(self):
+        """The failure this guards against: a quiet run persisting the moved-back pointer.
 
-        Without the floor at the state write, `delta_max` drops to the start of the lookback
-        window and the window silently widens from then on.
+        Without the floor at the state write, `delta_max` drops to the start of the window and the
+        window silently widens from then on.
         """
-        self._write_config(delta_lookback_days=10)
+        self._write_config(date_from="2026-07-27 02:16:26")
         self._write_state(self.STORED)
 
         self._run()
@@ -249,9 +247,8 @@ class TestDeltaLookbackRun(unittest.TestCase):
         self.assertEqual([20260727021626], FakeSapClient.sent_pointers)
         self.assertEqual(self.STORED, self._read_state()[self.ALIAS]["delta_max"])
 
-    @freeze_time("2026-08-06 02:16:26")
-    def test_run_without_lookback_is_unchanged(self):
-        self._write_config(delta_lookback_days=0)
+    def test_run_without_date_from_is_unchanged(self):
+        self._write_config(date_from="")
         self._write_state(self.STORED)
 
         self._run()
@@ -259,9 +256,8 @@ class TestDeltaLookbackRun(unittest.TestCase):
         self.assertEqual([self.STORED], FakeSapClient.sent_pointers)
         self.assertEqual(self.STORED, self._read_state()[self.ALIAS]["delta_max"])
 
-    @freeze_time("2026-08-06 02:16:26")
     def test_run_persists_a_newer_pointer_returned_by_sap(self):
-        self._write_config(delta_lookback_days=10)
+        self._write_config(date_from="2026-07-27")
         self._write_state(self.STORED)
         FakeSapClient.returned_pointer = 20260806021626
 
@@ -269,9 +265,8 @@ class TestDeltaLookbackRun(unittest.TestCase):
 
         self.assertEqual(20260806021626, self._read_state()[self.ALIAS]["delta_max"])
 
-    @freeze_time("2026-08-06 02:16:26")
-    def test_run_writes_the_table_with_lookback_enabled(self):
-        self._write_config(delta_lookback_days=10)
+    def test_run_writes_the_table_with_date_from(self):
+        self._write_config(date_from="2026-07-27")
         self._write_state(self.STORED)
         FakeSapClient.rows = [{"ACC_NUMBER": "1"}, {"ACC_NUMBER": "2"}]
 
@@ -282,18 +277,15 @@ class TestDeltaLookbackRun(unittest.TestCase):
         self.assertTrue(os.path.exists(table_path + ".manifest"))
         self.assertEqual(["ACC_NUMBER"], self._read_state()[self.ALIAS]["columns"])
 
-    @freeze_time("2026-08-06 02:16:26")
-    def test_run_fails_when_lookback_source_has_no_primary_key(self):
+    def test_run_fails_when_date_from_source_has_no_primary_key(self):
         """The guard must run before anything is written, and regardless of how many rows came back."""
-        FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
-
         for rows in ([], [{"ACC_NUMBER": "1"}]):
             with self.subTest(rows=len(rows)):
                 self.tearDown()
                 self.setUp()
                 FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
                 FakeSapClient.rows = rows
-                self._write_config(delta_lookback_days=10)
+                self._write_config(date_from="2026-07-27")
                 self._write_state(self.STORED)
 
                 with self.assertRaises(UserException):
@@ -304,10 +296,19 @@ class TestDeltaLookbackRun(unittest.TestCase):
                 self.assertFalse(os.path.exists(table_path + ".manifest"))
                 self.assertFalse(os.path.exists(os.path.join(self.data_dir, "out", "state.json")))
 
-    @freeze_time("2026-08-06 02:16:26")
-    def test_full_sync_row_with_a_leftover_lookback_value_is_unaffected(self):
+    def test_run_fails_fast_on_unparseable_date_from(self):
+        """A malformed Date Start fails before any fetch - no request is built."""
+        self._write_config(date_from="garbage")
+        self._write_state(self.STORED)
+
+        with self.assertRaises(UserException):
+            self._run()
+
+        self.assertEqual([], FakeSapClient.sent_pointers)
+
+    def test_full_sync_row_with_a_leftover_date_from_is_unaffected(self):
         """The field is hidden outside incremental sync, so a stale value must not fail the run."""
-        self._write_config(delta_lookback_days=10, sync_type="full_sync")
+        self._write_config(date_from="2026-07-27", sync_type="full_sync")
         self._write_state(self.STORED)
         FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
 
@@ -316,9 +317,8 @@ class TestDeltaLookbackRun(unittest.TestCase):
         self.assertEqual([None], FakeSapClient.sent_pointers)
         self.assertEqual(self.STORED, self._read_state()[self.ALIAS]["delta_max"])
 
-    @freeze_time("2026-08-06 02:16:26")
     def test_first_run_without_a_stored_pointer_full_syncs(self):
-        self._write_config(delta_lookback_days=10)
+        self._write_config(date_from="10 days ago")
 
         self._run()
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -3,6 +3,9 @@ Created on 12. 11. 2018
 
 @author: esner
 '''
+import json
+import shutil
+import tempfile
 import unittest
 import mock
 import os
@@ -12,6 +15,7 @@ from freezegun import freeze_time
 from keboola.component.exceptions import UserException
 
 from component import Component
+from sap_client.client import SAPClient
 
 
 class TestComponent(unittest.TestCase):
@@ -90,25 +94,24 @@ class TestDeltaLookback(unittest.TestCase):
     # --- validation --------------------------------------------------------------
 
     def test_invalid_lookback_values_raise(self):
-        for value in (-1, 3651, True, "10"):
+        for value in (-1, 366, 3650, True, "10"):
             with self.subTest(value=value):
                 with self.assertRaises(UserException):
                     Component._validate_delta_lookback_days(value)
 
     def test_valid_lookback_values_accepted(self):
-        for value in (0, 10, 3650):
+        for value in (0, 10, 365):
             with self.subTest(value=value):
                 self.assertEqual(value, Component._validate_delta_lookback_days(value))
 
     # --- what gets written back to state -----------------------------------------
 
     def test_state_does_not_regress_when_sap_returns_no_pointer(self):
-        """Reproduces the original failure: the lookback window walking backwards every run.
+        """On a quiet run SAP returns no delta pointer, and the stored one must survive intact.
 
-        On a run where nothing changed, SAP returns no delta pointer of its own, so the client's
-        maximum is just the (shifted) pointer it was handed. Persisting that would make the next
-        run shift an already-shifted pointer, and the window would creep back a further N days
-        every run, without limit and without any error.
+        The client seeds its own maximum with the pointer it was handed, so without the floor the
+        shifted pointer is what gets persisted: state drops back to the start of the lookback
+        window and stays there, and the window then widens by a day for every day that passes.
         """
         stored = self.STORED
         now = self.NOW
@@ -120,6 +123,9 @@ class TestDeltaLookback(unittest.TestCase):
 
             self.assertEqual(stored, persisted, f"pointer regressed on run {run + 1}")
             stored = persisted
+
+    def test_persisted_pointer_holds_when_sap_returns_an_older_pointer(self):
+        self.assertEqual(self.STORED, Component._persisted_delta_pointer(20260101000000, self.STORED))
 
     def test_state_advances_when_sap_returns_a_newer_pointer(self):
         persisted = Component._persisted_delta_pointer(20260806021626, self.STORED)
@@ -148,6 +154,142 @@ class TestDeltaLookback(unittest.TestCase):
         component.state = {"ACC_DOC_HEADER": {"delta_max": self.STORED}}
 
         self.assertIsNone(component._init_delta("full_sync", "ACC_DOC_HEADER"))
+
+
+class FakeSapClient(SAPClient):
+    """A SAPClient that talks to nothing.
+
+    Subclasses the real client so that the delta pointer bookkeeping under test - seeding
+    `delta_values` with the inbound pointer, and reducing it with `max_timestamp_or_id` - is the
+    real implementation rather than a restatement of it.
+    """
+
+    sent_pointers = []
+    returned_pointer = None
+    metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10, "KEY": True}}
+
+    def __init__(self, **kwargs):
+        # Deliberately not calling super().__init__: it would build a real HTTP client.
+        self.delta = kwargs.get("delta")
+        self.delta_values = []
+        if self.delta:
+            self.delta_values.append(self.delta)
+        FakeSapClient.sent_pointers.append(self.delta)
+
+    async def fetch(self, resource_alias, paging_method):
+        if FakeSapClient.returned_pointer:
+            self.delta_values.append(FakeSapClient.returned_pointer)
+
+
+class TestDeltaLookbackRun(unittest.TestCase):
+    """Drives the real `Component.run()` so the lookback wiring itself is covered, not just the helpers."""
+
+    ALIAS = "ACC_DOC_HEADER"
+    STORED = 20260805021626
+
+    def setUp(self):
+        self.data_dir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.data_dir, "in"))
+        os.makedirs(os.path.join(self.data_dir, "out", "tables"))
+        FakeSapClient.sent_pointers = []
+        FakeSapClient.returned_pointer = None
+        FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10, "KEY": True}}
+
+    def tearDown(self):
+        shutil.rmtree(self.data_dir, ignore_errors=True)
+
+    def _write_config(self, delta_lookback_days=0, sync_type="incremental_sync", load_type="incremental_load"):
+        config = {
+            "parameters": {
+                "authentication": {"server_url": "https://sap.example", "username": "u", "#password": "p"},
+                "source": {
+                    "resource_alias": self.ALIAS,
+                    "sync_type": sync_type,
+                    "paging_method": "key",
+                    "delta_lookback_days": delta_lookback_days,
+                },
+                "destination": {"output_table_name": "", "load_type": load_type},
+            }
+        }
+        with open(os.path.join(self.data_dir, "config.json"), "w") as f:
+            json.dump(config, f)
+
+    def _write_state(self, delta_max):
+        with open(os.path.join(self.data_dir, "in", "state.json"), "w") as f:
+            json.dump({self.ALIAS: {"delta_max": delta_max}}, f)
+
+    def _read_state(self):
+        with open(os.path.join(self.data_dir, "out", "state.json")) as f:
+            return json.load(f)
+
+    def _run(self):
+        with mock.patch.dict(os.environ, {"KBC_DATADIR": self.data_dir}):
+            with mock.patch("component.SAPClient", FakeSapClient):
+                Component().run()
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_run_sends_lookback_pointer_but_persists_the_stored_one(self):
+        """The failure this guards against: a quiet run persisting the shifted pointer.
+
+        Without the floor at the state write, `delta_max` drops to the start of the lookback
+        window and the window silently widens from then on.
+        """
+        self._write_config(delta_lookback_days=10)
+        self._write_state(self.STORED)
+
+        self._run()
+
+        self.assertEqual([20260727021626], FakeSapClient.sent_pointers)
+        self.assertEqual(self.STORED, self._read_state()[self.ALIAS]["delta_max"])
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_run_without_lookback_is_unchanged(self):
+        self._write_config(delta_lookback_days=0)
+        self._write_state(self.STORED)
+
+        self._run()
+
+        self.assertEqual([self.STORED], FakeSapClient.sent_pointers)
+        self.assertEqual(self.STORED, self._read_state()[self.ALIAS]["delta_max"])
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_run_persists_a_newer_pointer_returned_by_sap(self):
+        self._write_config(delta_lookback_days=10)
+        self._write_state(self.STORED)
+        FakeSapClient.returned_pointer = 20260806021626
+
+        self._run()
+
+        self.assertEqual(20260806021626, self._read_state()[self.ALIAS]["delta_max"])
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_run_fails_when_lookback_source_has_no_primary_key(self):
+        self._write_config(delta_lookback_days=10)
+        self._write_state(self.STORED)
+        FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
+
+        with self.assertRaises(UserException):
+            self._run()
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_full_sync_row_with_a_leftover_lookback_value_is_unaffected(self):
+        """The field is hidden outside incremental sync, so a stale value must not fail the run."""
+        self._write_config(delta_lookback_days=10, sync_type="full_sync")
+        self._write_state(self.STORED)
+        FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
+
+        self._run()
+
+        self.assertEqual([None], FakeSapClient.sent_pointers)
+        self.assertEqual(self.STORED, self._read_state()[self.ALIAS]["delta_max"])
+
+    @freeze_time("2026-08-06 02:16:26")
+    def test_first_run_without_a_stored_pointer_full_syncs(self):
+        self._write_config(delta_lookback_days=10)
+
+        self._run()
+
+        self.assertEqual([False], FakeSapClient.sent_pointers)
 
 
 if __name__ == "__main__":

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -6,7 +6,10 @@ Created on 12. 11. 2018
 import unittest
 import mock
 import os
+from datetime import datetime
 from freezegun import freeze_time
+
+from keboola.component.exceptions import UserException
 
 from component import Component
 
@@ -21,6 +24,130 @@ class TestComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             comp = Component()
             comp.run()
+
+
+class TestDeltaLookback(unittest.TestCase):
+    """Covers `source.delta_lookback_days` (SUPPORT-17281).
+
+    NOW is the run time; STORED is a pointer the previous run left behind, one day old.
+    """
+
+    NOW = datetime(2026, 8, 6, 2, 16, 26)
+    STORED = 20260805021626
+
+    def _shift(self, pointer, lookback_days, now=None):
+        return Component._apply_delta_lookback(pointer, lookback_days, now or self.NOW)
+
+    # --- the pointer sent to SAP ------------------------------------------------
+
+    def test_sent_pointer_is_now_minus_lookback(self):
+        """The customer's ask: 10 days back from today, not from the stored pointer."""
+        self.assertEqual(20260727021626, self._shift(self.STORED, 10))
+
+    def test_sent_pointer_falls_back_to_stored_when_schedule_is_behind(self):
+        """A run that is behind must resume from the stored pointer, never skip the gap."""
+        stored = 20260601000000
+        self.assertEqual(stored, self._shift(stored, 10))
+
+    def test_sent_pointer_is_never_newer_than_stored(self):
+        for lookback_days in (1, 5, 10, 365):
+            with self.subTest(lookback_days=lookback_days):
+                self.assertLessEqual(self._shift(self.STORED, lookback_days), self.STORED)
+
+    def test_date_only_pointer_keeps_its_format(self):
+        self.assertEqual(20260727, self._shift(20260805, 10))
+
+    def test_string_pointer_stays_a_string(self):
+        shifted = self._shift("20260805021626", 10)
+        self.assertEqual("20260727021626", shifted)
+        self.assertIsInstance(shifted, str)
+
+    def test_month_boundary(self):
+        now = datetime(2026, 3, 1)
+        self.assertEqual(20260228000000, self._shift(20260301000000, 1, now))
+
+    def test_leap_day(self):
+        now = datetime(2028, 3, 1)
+        self.assertEqual(20280229000000, self._shift(20280301000000, 1, now))
+
+    # --- pointers a lookback cannot be expressed on -----------------------------
+
+    def test_sequential_id_pointer_raises(self):
+        with self.assertRaises(UserException):
+            self._shift(12345, 10)
+
+    def test_date_like_sequential_id_raises_instead_of_being_corrupted(self):
+        """`10000101` parses as year 1000; shifting it would jump the id back by millions."""
+        for pointer in (10000101, 12340101, 20260101021626000):
+            with self.subTest(pointer=pointer):
+                with self.assertRaises(UserException):
+                    self._shift(pointer, 10)
+
+    def test_non_numeric_pointer_raises(self):
+        with self.assertRaises(UserException):
+            self._shift("2026-08-05", 10)
+
+    # --- validation --------------------------------------------------------------
+
+    def test_invalid_lookback_values_raise(self):
+        for value in (-1, 3651, True, "10"):
+            with self.subTest(value=value):
+                with self.assertRaises(UserException):
+                    Component._validate_delta_lookback_days(value)
+
+    def test_valid_lookback_values_accepted(self):
+        for value in (0, 10, 3650):
+            with self.subTest(value=value):
+                self.assertEqual(value, Component._validate_delta_lookback_days(value))
+
+    # --- what gets written back to state -----------------------------------------
+
+    def test_state_does_not_regress_when_sap_returns_no_pointer(self):
+        """Reproduces the original failure: the lookback window walking backwards every run.
+
+        On a run where nothing changed, SAP returns no delta pointer of its own, so the client's
+        maximum is just the (shifted) pointer it was handed. Persisting that would make the next
+        run shift an already-shifted pointer, and the window would creep back a further N days
+        every run, without limit and without any error.
+        """
+        stored = self.STORED
+        now = self.NOW
+
+        for run in range(5):
+            sent = self._shift(stored, 10, now)
+            # SAP reports nothing changed -> the client's max is the pointer it was given.
+            persisted = Component._persisted_delta_pointer(sent, stored)
+
+            self.assertEqual(stored, persisted, f"pointer regressed on run {run + 1}")
+            stored = persisted
+
+    def test_state_advances_when_sap_returns_a_newer_pointer(self):
+        persisted = Component._persisted_delta_pointer(20260806021626, self.STORED)
+        self.assertEqual(20260806021626, persisted)
+
+    def test_persisted_pointer_without_stored_value_is_the_clients_max(self):
+        """First run: nothing stored yet, so there is no floor to apply."""
+        self.assertEqual(20260806021626, Component._persisted_delta_pointer(20260806021626, False))
+        self.assertIsNone(Component._persisted_delta_pointer(None, False))
+
+    # --- unchanged behaviour when the option is not set ---------------------------
+
+    def test_unset_lookback_leaves_the_stored_pointer_untouched(self):
+        """With the option off, the pointer sent and the pointer persisted are both the stored one."""
+        state = {"ACC_DOC_HEADER": {"delta_max": self.STORED}}
+        component = Component.__new__(Component)
+        component.state = state
+
+        stored = component._init_delta("incremental_sync", "ACC_DOC_HEADER")
+
+        self.assertEqual(self.STORED, stored)
+        self.assertEqual(self.STORED, Component._persisted_delta_pointer(stored, stored))
+
+    def test_full_sync_ignores_the_stored_pointer(self):
+        component = Component.__new__(Component)
+        component.state = {"ACC_DOC_HEADER": {"delta_max": self.STORED}}
+
+        self.assertIsNone(component._init_delta("full_sync", "ACC_DOC_HEADER"))
 
 
 if __name__ == "__main__":

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -289,6 +289,7 @@ class TestDeltaLookbackRun(unittest.TestCase):
 
         for rows in ([], [{"ACC_NUMBER": "1"}]):
             with self.subTest(rows=len(rows)):
+                self.tearDown()
                 self.setUp()
                 FakeSapClient.metadata = {"ACC_NUMBER": {"TYPE": "CHAR", "LENGTH": 10}}
                 FakeSapClient.rows = rows


### PR DESCRIPTION
## What

Adds `source.date_from` — a **Date Start** for incremental sync (string, optional, incremental sync only). It accepts a relative value (`10 days ago`) or an absolute one (`2026-01-01`), parsed with `keboola.utils.parse_datetime_interval`. When set, the delta pointer **sent** to SAP becomes `min(stored pointer, date_from resolved against now)`, so each incremental run re-fetches changes since that date instead of resuming exactly where the last run stopped.

The pointer **persisted** to state is floored by the pointer the run started from, so it never moves backwards and the window stays anchored to the current date instead of creeping wider.

There is **no Date End**: SAP's delta interface (`?delta=<pointer>`, a single lower bound — see the ADPA API spec) takes no upper bound, so the window always runs from Date Start to now. The field's tooltip and the README state this.

Two smaller fixes ride along, both described below.

## Why

Resolves CFTL-769 / SUPPORT-17281.

Some SAP source tables cannot be tracked reliably by their change column — changes land with backdated timestamps, so an incremental sync that resumes precisely from the stored pointer misses them. Switching those tables to full sync is not viable: the table in question is ~100 million rows.

Date Start is the canonical Keboola pattern for controlling a fetch window (over a bespoke "lookback days" knob), and it does more: a relative value gives the recurring overlap the ticket asked for, while an absolute value gives a one-off backfill / re-pull from a fixed date — the path a forward-only watermark otherwise lacks. Anchoring on the current date is what keeps the window stable; flooring at the stored pointer keeps it safe — a run behind schedule still resumes from where it left off, so the fetched window is always a **superset** of today's behaviour.

## Backwards compatibility

**None for existing configs — the new behaviour is opt-in and defaults to today's behaviour.**

Reach: this component is run by a single multitenant client.

With `date_from` absent or empty, every new branch is skipped and the code path is identical to before — verified by driving the real `run()` and asserting the pointer sent and the state written both equal the stored pointer. The config schema change is strictly additive: a new optional string field, not in any `required` array, with **no** schema-level `default`, so nothing is serialized into existing row configs.

Two changes **do** alter behaviour for configs that never set the new field, and both are deliberate:

1. **`setdefault` at the state write.** Previously a run that fetched no rows yet received a delta pointer raised `KeyError` → exit 2, and the row stayed broken. It now writes the pointer and succeeds.
2. **`requirements.txt` repin.** The pin was a git branch that was merged upstream and **deleted**, so `pip install` fails and the Docker build cannot produce an image at all — CI has been unable to build since. Pinned to `keboola.http-client>=1.2.0` (the released form of that exact merge commit). Every `AsyncHttpClient` argument `SAPClient` passes is unchanged; the one runtime difference vs. the last deployed image is retry-backoff timing at `retries=3` (`1s/2s/4s` → `0s/2s/4s`).

Not changed: output schema, columns or order, native datatypes, manifests, state shape, auth, sync actions.

## Guard rails

The option fails with an explanation rather than quietly doing nothing where it cannot work:

- **Unparseable Date Start** → `UserException`, raised before any fetch.
- **Non-timestamp delta pointer** → `UserException`. Only `YYYYMMDD` / `YYYYMMDDHHMMSS` pointers can express a date window; a plausible-year check keeps sequential ids that happen to parse as a date out of the timestamp path.
- **`incremental_load` with no primary key** → `UserException`. Re-fetching an overlap re-emits rows already in Storage; with no primary key Keboola appends them, so every changed row would land once per run. Checked against column metadata (config + source, not run data) and before anything is written.
- **`full_load` + Date Start** → warning only.
- **Wide window** (> 31 days) → warning. A delta fetch is a single un-paginated request, so the window must return in one response inside the timeout. Not hard-capped: an absolute backfill date is a legitimate wide window, and the worst case is a self-chosen request that times out, not corruption.
- **Inert outside incremental sync**, and on the first run before any pointer is stored (the format can't be known yet) — the run behaves exactly as with Date Start empty.

## Testing

`flake8` clean, 26 tests green — locally and inside the actual `python:3.13-slim` build image via `scripts/build_n_test.sh`.

Two tests protect the **wiring**, not just helpers, by driving the real `Component.run()`:
- `test_run_sends_date_from_pointer_but_persists_the_stored_one` — reverting the state floor at the call site turns it red. Without the floor, a run where SAP reports nothing changed persists the moved-back pointer and the window widens from then on.
- `test_run_fails_when_date_from_source_has_no_primary_key` — asserts the guard fires at both zero and non-zero rows and that neither a manifest nor a state file is written; moving the guard back inside the row-writing branch fails it.

Relative-date assertions are date-level (the parser applies a local-time shift to relative values); exact-value assertions use absolute dates, which parse deterministically. The fake client subclasses the real `SAPClient` and does not override the pointer bookkeeping, so `delta_values` seeding and the `max_timestamp_or_id` reduction under test are the real implementations.

## Supersedes

Supersedes #6. That PR shifts the stored pointer by N days rather than anchoring on the current date (different quantities once the pointer lags wall-clock), hands the shifted value to the client whose constructor seeds its maximum with it (so a quiet run persists the shifted value and the window walks backwards), treats a non-shiftable pointer as a warning-and-continue, and has no duplicate-row guard. CI never executed on that branch. Leaving it open for the maintainer to close.

## Open — Date End

Whether a true Date End is possible depends on the SAP-side ADPA service (a partner-built ABAP add-on) supporting an upper bound or a `$filter`-style grammar; the documented surface (CFT-1016 spec, Nov-2025 vendor audit) shows delta as lower-bound-only, but that spec is provably incomplete (it omits the `key_min`/`key_max` capability the service does have). Question is going to the service owner via the partner. Until then, Date Start alone is honest.
